### PR TITLE
fix: large stickers can exceed stack size in v8

### DIFF
--- a/src/lib/stickers-client.ts
+++ b/src/lib/stickers-client.ts
@@ -174,11 +174,11 @@ export default function StickersClientFactory(options: StickersClientOptions): S
       return rawImageData;
     }
 
-    const decodedImageData: string[] = [];
+    const decodedImageData: Array<string> = [];
     for (const codePoint of rawImageData) {
       decodedImageData.push(...String.fromCodePoint(codePoint));
     }
-    const base64Data = base64Encoder(decodedImageData.join(""));
+    const base64Data = base64Encoder(decodedImageData.join(''));
     return `data:image/webp;base64,${base64Data}`;
   };
 

--- a/src/lib/stickers-client.ts
+++ b/src/lib/stickers-client.ts
@@ -174,7 +174,11 @@ export default function StickersClientFactory(options: StickersClientOptions): S
       return rawImageData;
     }
 
-    const base64Data = base64Encoder(String.fromCodePoint(...rawImageData));
+    const decodedImageData: string[] = [];
+    for (const codePoint of rawImageData) {
+      decodedImageData.push(...String.fromCodePoint(codePoint));
+    }
+    const base64Data = base64Encoder(decodedImageData.join(""));
     return `data:image/webp;base64,${base64Data}`;
   };
 


### PR DESCRIPTION
large stickers can cause following error in v8-based browsers:
```
Uncaught (in promise) RangeError: Maximum call stack size exceeded
    at main.js:23:6407
    at Generator.next (<anonymous>)
    at o (main.js:1:1254)
```

the culprit is the unrolling of `rawImageData`. 

since individual codepoints can be converted to their string representation independently, buffering the results in an array resolves the issue.